### PR TITLE
Potential fix for code scanning alert no. 11: DOM text reinterpreted as HTML

### DIFF
--- a/extension/assets/internal/scripts/app.js
+++ b/extension/assets/internal/scripts/app.js
@@ -1192,14 +1192,28 @@
                     each.text = I18n.getText('todoListPlaceholder')
                 }
 
-                $('#todo-list .items').prepend($(`
-                    <div class="item ${each.checked ? 'checked' : ''}">
-                        <input type="checkbox" class="item-checkbox" ${each.checked ? 'checked' : ''}>
-                        <span class="item-textbox" contenteditable="true" data-placeholder="${I18n.getText('todoListEntryPlaceholder')}">${each.text.replace(/\n/gi, '<br>')}</span>
-                        <button class="move"><i class="fa fa-arrows"></i></button>
-                        <button class="delete"><i class="fa fa-close"></i></button>
-                    </div>
-                `))
+                const $item = $('<div class="item"></div>')
+                if (each.checked) {
+                    $item.addClass('checked')
+                }
+
+                const $checkbox = $('<input type="checkbox" class="item-checkbox">').prop('checked', !!each.checked)
+                const $textbox = $('<span class="item-textbox" contenteditable="true"></span>')
+                    .attr('data-placeholder', I18n.getText('todoListEntryPlaceholder'))
+
+                const lines = String(each.text || '').split(/\n/gi)
+                lines.forEach((line, index) => {
+                    if (index > 0) {
+                        $textbox.append('<br>')
+                    }
+                    $textbox.append(document.createTextNode(line))
+                })
+
+                const $moveButton = $('<button class="move"><i class="fa fa-arrows"></i></button>')
+                const $deleteButton = $('<button class="delete"><i class="fa fa-close"></i></button>')
+
+                $item.append($checkbox, $textbox, $moveButton, $deleteButton)
+                $('#todo-list .items').prepend($item)
             })
         },
 


### PR DESCRIPTION
Potential fix for [https://github.com/novalagung/muslimboard/security/code-scanning/11](https://github.com/novalagung/muslimboard/security/code-scanning/11)

Best fix: stop injecting `each.text` into an HTML string. Build DOM nodes and assign user text using `.text(...)` (or `textContent`), then only add `<br>` formatting in a safe way (convert newlines after escaping by using jQuery-created text and joining with `<br>` nodes).

In `extension/assets/internal/scripts/app.js`, update `ensureTodoListItemsAppear()` (around lines 1195–1202) so:
- the item container HTML contains no untrusted interpolation,
- `data-placeholder` uses a safe attribute setter,
- textbox content is set via text-safe operations, preserving line breaks by splitting on `\n` and inserting `<br>` elements.

No new imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
