### PR TITLE
Potential fix for code scanning alert no. 10: Clear text storage of sensitive information

### DIFF
--- a/extension/assets/internal/scripts/utility.js
+++ b/extension/assets/internal/scripts/utility.js
@@ -36,16 +36,77 @@ const Utility = {
             if (callNow) func.apply(context, args);
         };
     },
-    getCurrentLocationCoordinate: () => new Promise((resolve, reject) => {
-        const useCoordinateCache = () => {
-            const coordinateCache = JSON.parse(localStorage.getItem('data-coordinate-cache') || '{}')
-            Utility.log('timeout. use last cached location', coordinateCache)
-            if (Object.keys(coordinateCache).length > 0) {
-                resolve(coordinateCache)
-            } else {
-                localStorage.removeItem('data-coordinate-cache')
-                reject(new Error(I18n.getText('promptErrorFailToGetLocationInfo')))
-            }
+    _textEncoder: new TextEncoder(),
+    _textDecoder: new TextDecoder(),
+    _bytesToBase64: (bytes) => btoa(String.fromCharCode(...bytes)),
+    _base64ToBytes: (base64) => Uint8Array.from(atob(base64), (c) => c.charCodeAt(0)),
+    getCoordinateCacheCryptoKey: async () => {
+        const keyMaterial = await crypto.subtle.importKey(
+            'raw',
+            Utility._textEncoder.encode('coordinate-cache-key-v1'),
+            { name: 'PBKDF2' },
+            false,
+            ['deriveKey']
+        )
+        return crypto.subtle.deriveKey(
+            {
+                name: 'PBKDF2',
+                salt: Utility._textEncoder.encode('extension-coordinate-cache-salt-v1'),
+                iterations: 100000,
+                hash: 'SHA-256'
+            },
+            keyMaterial,
+            { name: 'AES-GCM', length: 256 },
+            false,
+            ['encrypt', 'decrypt']
+        )
+    },
+    encryptCoordinateCache: async (plainText) => {
+        const key = await Utility.getCoordinateCacheCryptoKey()
+        const iv = crypto.getRandomValues(new Uint8Array(12))
+        const encrypted = await crypto.subtle.encrypt(
+            { name: 'AES-GCM', iv },
+            key,
+            Utility._textEncoder.encode(plainText)
+        )
+        return JSON.stringify({
+            iv: Utility._bytesToBase64(iv),
+            data: Utility._bytesToBase64(new Uint8Array(encrypted))
+        })
+    },
+    decryptCoordinateCache: async (cipherPayload) => {
+        const payload = JSON.parse(cipherPayload)
+        const key = await Utility.getCoordinateCacheCryptoKey()
+        const decrypted = await crypto.subtle.decrypt(
+            { name: 'AES-GCM', iv: Utility._base64ToBytes(payload.iv) },
+            key,
+            Utility._base64ToBytes(payload.data)
+        )
+        return Utility._textDecoder.decode(decrypted)
+    },
+    getCurrentLocationCoordinate: () => new Promise(async (resolve, reject) => {
+        const useCoordinateCache = async () => {
+            try {
+                const rawCache = localStorage.getItem('data-coordinate-cache')
+                if (!rawCache) throw new Error('empty cache')
+
+                let coordinateCache = {}
+                try {
+                    const decryptedCache = await Utility.decryptCoordinateCache(rawCache)
+                    coordinateCache = JSON.parse(decryptedCache || '{}')
+                } catch (decryptErr) {
+                    coordinateCache = JSON.parse(rawCache || '{}')
+                }
+
+                Utility.log('timeout. use last cached location', coordinateCache)
+                if (Object.keys(coordinateCache).length > 0) {
+                    resolve(coordinateCache)
+                    return
+                }
+            } catch (e) {}
+
+            localStorage.removeItem('data-coordinate-cache')
+            reject(new Error(I18n.getText('promptErrorFailToGetLocationInfo')))
         }
 
         if (!navigator.geolocation) {
@@ -56,7 +117,7 @@ const Utility = {
         navigator.geolocation.clearWatch(this.geoLocationWatchObject)
         navigator.geolocation.getCurrentPosition($.noop, $.noop, {})
         navigator.geolocation.getCurrentPosition(
-            (result) => {
+            async (result) => {
                 const coordinate = {
                     coords: {
                         latitude: result.coords.latitude,
@@ -64,7 +125,8 @@ const Utility = {
                     }
                 }
                 Utility.log('current coordinate found at', coordinate.coords)
-                localStorage.setItem('data-coordinate-cache', JSON.stringify(coordinate))
+                const encryptedCoordinate = await Utility.encryptCoordinateCache(JSON.stringify(coordinate))
+                localStorage.setItem('data-coordinate-cache', encryptedCoordinate)
                 resolve(coordinate)
             }, 
             useCoordinateCache,


### PR DESCRIPTION
Potential fix for [https://github.com/novalagung/muslimboard/security/code-scanning/10](https://github.com/novalagung/muslimboard/security/code-scanning/10)

To fix this without changing behavior, encrypt coordinate cache data before writing to `localStorage`, and decrypt it when reading. Since this is browser JS, the best practical approach is to use the Web Crypto API (`crypto.subtle`) with AES-GCM and per-encryption random IV. We also add helper methods in `Utility` for key derivation (from a stable extension-specific secret/salt), encrypt/decrypt, and safe decode fallback for legacy cleartext entries.

In `extension/assets/internal/scripts/utility.js`:
- Update `getCurrentLocationCoordinate` to be `async` inside the Promise executor so it can `await` encryption/decryption.
- Replace line storing `JSON.stringify(coordinate)` with encrypted payload storage.
- Replace cache read path to decrypt stored payload before JSON parse.
- Add Utility helper methods (inside `Utility`) for:
  - UTF-8 encode/decode
  - Base64 conversion for byte arrays
  - `getCoordinateCacheCryptoKey()`
  - `encryptCoordinateCache(plainText)`
  - `decryptCoordinateCache(cipherText)`
- Keep fallback compatibility: if decrypt fails, attempt plain JSON parse so existing cached data still works, then overwrite with encrypted data on next successful location retrieval.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
