### PR TITLE
change transition hide and show todo list

### DIFF
--- a/extension/assets/internal/scripts/i18n.js
+++ b/extension/assets/internal/scripts/i18n.js
@@ -833,5 +833,10 @@ const I18n = {
                 $e.text(text)
             }
         })
+        $('[data-i18n-title]').each((i, e) => {
+            const $e = $(e)
+            const key = $e.attr('data-i18n-title')
+            $e.attr('title', I18n.getText(key))
+        })
     }
 }

--- a/extension/assets/internal/stylesheets/style.css
+++ b/extension/assets/internal/stylesheets/style.css
@@ -426,21 +426,24 @@ body.show-todo-list #wise-word {
 #todo-list {
     overflow: hidden;
     position: absolute;
-    width: 240px;
-    right: 30px;
-    bottom: 16px;
+    width: 37px;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
     background-color: rgba(255, 255, 255, 0.92);
-    border-radius: 10px;
+    border-radius: 10px 0 0 10px;
     z-index: 5;
-    transition: ease-in-out bottom 300ms;
-    transition-property: bottom, background-color;
+    transition: width 300ms ease-in-out, right 300ms ease-in-out, top 300ms ease-in-out, transform 300ms ease-in-out, background-color 300ms ease-in-out, border-radius 300ms ease-in-out, height 300ms ease-in-out;
     height: 37px;
 }
 body.show-todo-list #todo-list {
     top: 30px;
+    transform: translateY(0);
     bottom: 30px;
+    right: 30px;
     width: 420px;
     height: auto;
+    border-radius: 10px;
 }
 #todo-list:hover {
     background-color: white;
@@ -454,13 +457,17 @@ body.show-todo-list #todo-list {
     cursor: pointer;
     color: #404040;
     font-size: 12px;
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 7;
 }
 body.show-todo-list #todo-list .wrapper .toggler {
     height: 40px;
     padding: 11px 10px;
 }
 #todo-list .wrapper .toggler .true {
-    display: inline;
+    display: none;
 }
 #todo-list .wrapper .toggler .false {
     display: none;
@@ -472,10 +479,14 @@ body.show-todo-list #todo-list .wrapper .toggler .false {
     display: inline;
 }
 #todo-list .wrapper .toggler .fa {
+    margin-right: 0;
+}
+body.show-todo-list #todo-list .wrapper .toggler .fa {
     margin-right: 5px;
 }
 #todo-list .wrapper .items {
     overflow-y: auto;
+    padding-top: 60px;
 }
 #todo-list .wrapper .items .add,
 #todo-list .wrapper .items .import,
@@ -492,22 +503,22 @@ body.show-todo-list #todo-list .wrapper .toggler .false {
     box-shadow: 0 1px 6px 0 rgba(32,33,36,0.28);
     position: absolute;
     top: 10px;
-    right: 10px;
+    left: 10px;
     display: none;
     z-index: 6;
     opacity: 0.9;
     transition: opacity 100ms ease-in-out, transform 100ms ease-in-out;
 }
 #todo-list .wrapper .items .add {
-    right: 106px;
+    left: 10px;
     background-color: #00b16a;
 }
 #todo-list .wrapper .items .import {
-    right: 58px;
+    left: 58px;
     background-color: #f39c12;
 }
 #todo-list .wrapper .items .export {
-    right: 10px;
+    left: 106px;
     background-color: #008c9e;
 }
 body.show-todo-list #todo-list .wrapper .items .add,

--- a/extension/index.html
+++ b/extension/index.html
@@ -133,7 +133,7 @@
 
     <div id="todo-list">
         <div class="wrapper">
-            <div class="toggler">
+            <div class="toggler" data-i18n-title="todoListHeaderShow">
                 <i class="fa fa-eye"></i>
                 <span class="true" data-i18n="todoListHeaderShow">Klik untuk menampilkan todo list</span>
                 <span class="false" data-i18n="todoListHeaderHide">Klik untuk menyembunyikan todo list</span>


### PR DESCRIPTION
This pull request primarily updates the UI and internationalization handling for the todo list feature in the extension. The main changes include improvements to the todo list's appearance, positioning, and transitions, as well as enhancements to internationalization support for tooltips.

UI/UX improvements to the todo list:

* Adjusted the default and expanded positioning, width, height, and border-radius of the `#todo-list` for a more modern and dynamic appearance, including new transitions and a vertical centering effect.
* Updated the toggler's styling and positioning, making it absolutely positioned in the top-right corner, and changed the visibility logic for the show/hide icons.
* Improved the layout and padding of the `.items` container and the toggler icon margins for better visual alignment.
* Repositioned the `.add`, `.import`, and `.export` buttons from the right to the left side within the todo list for better consistency and accessibility.

Internationalization enhancements:

* Added support for translating the `title` attribute of elements with a `data-i18n-title` attribute, ensuring tooltips can be localized.
* Applied the new `data-i18n-title` attribute to the todo list toggler in `index.html` for localized tooltips.